### PR TITLE
Updates example for latest compose version

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -97,8 +97,6 @@ FROM sykescottages/cdk:version
 ### Docker Compose
 
 ```yaml
-version: '3'
-
 services:
     cdk:
         image: sykescottages/cdk:latest


### PR DESCRIPTION
Removes deprecated version tag property from docker compose example in the readme.